### PR TITLE
WIP: Add arm images to docker builds to allow RPI's to host api

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches:
+    branches: 
       - master
 
 jobs:
@@ -22,12 +22,14 @@ jobs:
       - name: Get dependencies
         run: |
           go get -v -t -d
+          
       - name: Build
         run: |
           make build
       
       - name: Setup docker
         uses: docker-practice/actions-setup-docker@0.0.1
+        
       - name: Docker Buildx
         uses: crazy-max/ghaction-docker-buildx@v1.0.5
 
@@ -36,7 +38,9 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
+          echo Logging Into Docker
+          docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+          echo Installing BuildX
           make setup-buildx
+          echo Building Containers and Publishing them
           make img-buildx
-          # docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-          # make img-push

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,8 @@ jobs:
         uses: docker-practice/actions-setup-docker@0.0.1
 
       - name: Build and push docker image
-        using: "registry.gitlab.com/ericvh/docker-buildx-qemu"
+        runs:
+          using: "registry.gitlab.com/ericvh/docker-buildx-qemu"
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,10 +28,10 @@ jobs:
       
       - name: Setup docker
         uses: docker-practice/actions-setup-docker@0.0.1
+      - name: Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v1.0.5
 
       - name: Build and push docker image
-        runs:
-          using: "registry.gitlab.com/ericvh/docker-buildx-qemu"
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,6 +37,6 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           make setup-buildx
-          make img-build-arm32
+          make img-buildx
           # docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
           # make img-push

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,10 +30,12 @@ jobs:
         uses: docker-practice/actions-setup-docker@0.0.1
 
       - name: Build and push docker image
+        using: "registry.gitlab.com/ericvh/docker-buildx-qemu"
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
-          make img-build
+          make setup-buildx
+          make img-build-arm32
           # docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
           # make img-push

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,13 @@ img-push:
 docs:
 	apidoc -i controllers -o docs
 
+.PHONY: setup-buildx
 setup-buildx:
     update-binfmts --enable
     docker buildx create --driver docker-container --use
     docker buildx inspect --bootstrap
     docker buildx ls
 
+.PHONY: img-build-arm32
 img-build-arm32
     docker buildx build --platform linux/arm --progress plain --pull -t "atechnohazard/potatosync" .

--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,4 @@ setup-buildx:
 
 .PHONY: img-buildx
 img-buildx:
-	docker buildx build --platform linux/arm,linux/arm64,linux/amd64 --progress plain --pull -t "atechnohazard/potatosync" .
+	docker buildx build --platform linux/arm,linux/arm64,linux/amd64 --progress plain --pull -t "atechnohazard/potatosync" --push .

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,6 @@ setup-buildx:
 	docker buildx inspect --bootstrap
 	docker buildx ls
 
-.PHONY: img-build-arm32
-img-build-arm32:
-	docker buildx build --platform linux/arm --progress plain --pull -t "atechnohazard/potatosync" .
+.PHONY: img-buildx
+img-buildx:
+	docker buildx build --platform linux/arm,linux/amd64,linux/x86 --progress plain --pull -t "atechnohazard/potatosync" .

--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,4 @@ setup-buildx:
 
 .PHONY: img-buildx
 img-buildx:
-	docker buildx build --platform linux/arm,linux/amd64,linux/x86 --progress plain --pull -t "atechnohazard/potatosync" .
+	docker buildx build --platform linux/arm,linux/arm64,linux/amd64 --progress plain --pull -t "atechnohazard/potatosync" .

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,12 @@ img-push:
 .PHONY: docs
 docs:
 	apidoc -i controllers -o docs
+
+setup-buildx:
+    update-binfmts --enable
+    docker buildx create --driver docker-container --use
+    docker buildx inspect --bootstrap
+    docker buildx ls
+
+img-build-arm32
+    docker buildx build --platform linux/arm --progress plain --pull -t "atechnohazard/potatosync" .

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ docs:
 
 .PHONY: setup-buildx
 setup-buildx:
-    update-binfmts --enable
-    docker buildx create --driver docker-container --use
-    docker buildx inspect --bootstrap
-    docker buildx ls
+	update-binfmts --enable
+	docker buildx create --driver docker-container --use
+	docker buildx inspect --bootstrap
+	docker buildx ls
 
 .PHONY: img-build-arm32
-img-build-arm32
-    docker buildx build --platform linux/arm --progress plain --pull -t "atechnohazard/potatosync" .
+img-build-arm32:
+	docker buildx build --platform linux/arm --progress plain --pull -t "atechnohazard/potatosync" .


### PR DESCRIPTION
By cross-building with buildx for arm, people can host the api on RPI without compiling it themselves. I have so far tested everything except publishing to docker hub.