### PR TITLE
Added facility to disable user registrations via environment variable.

### DIFF
--- a/models/accounts.go
+++ b/models/accounts.go
@@ -84,6 +84,11 @@ func (acc *Account) Validate() (map[string]interface{}, bool) {
 
 // Create a new user account
 func (acc *Account) Create() map[string]interface{} {
+	// Abort immediately if registration disabled.
+	if os.Getenv("allow_registrations") == "false" {
+		return u.Message(false, "RegistrationDisabledError")
+	}
+
 	if res, ok := acc.Validate(); !ok {
 		return res
 	}


### PR DESCRIPTION
For self-hosters of the sync server, it would be desirable to have the option of disabling user registrations such that only trusted users can store their wares on the owner's personal inf.

This small change simply checks the `allow_registrations` env variable and aborts the registration prior to any request validation if the owner has disabled registrations within `docker.env`:

`allow_registrations=false`